### PR TITLE
Added feature to run a build script before the copy is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,21 @@ Add to `Gemfile`:
 
     gem "capistrano-strategy-copy-partial"
 
-## Configuration
+## Mandatory Configuration
 
-Use next options:
+Use these options:
 
     set :deploy_via,   :copy_partial
-    set :copy_partial, "path/for/deploy"
+    set :copy_partial, "path/for/deploy"  #NOTE this path is relative to the repository root
     set :copy_strategy, :export
+
+## Optional Configuration
+
+You may also optionally run a build command by setting:
+
+    set :build_dir,    "path/where/build_script/is_run"  #NOTE this path is relative to the repository root
+    set :build_script, "mvn clean install"
+
 
 ## Licence
 

--- a/lib/capistrano-strategy-copy-partial/version.rb
+++ b/lib/capistrano-strategy-copy-partial/version.rb
@@ -1,3 +1,3 @@
 module CapistranoStrategyCopyPartial
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/lib/capistrano/recipes/deploy/strategy/copy_partial.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy_partial.rb
@@ -41,6 +41,11 @@ class Capistrano::Deploy::Strategy::CopyPartial < Capistrano::Deploy::Strategy::
       logger.debug "getting (via #{copy_strategy}) revision #{revision} to #{destination}"
       system(command)
 
+      if exists?(:build_dir) && exists?(:build_script)
+        logger.debug "running build_script '#{build_script}' in directory #{destination}/#{build_dir}"
+        system("cd #{destination}/#{build_dir} && #{build_script}")
+      end
+
       if copy_exclude.any?
         logger.debug "processing exclusions..."
         if copy_exclude.any?


### PR DESCRIPTION
The feature is totally optional and nothing will break if you leave the the build_dir and build_script settings empty.

Updated readme.md to explain the new settings
